### PR TITLE
Add simulate_py JSON input docs

### DIFF
--- a/documentation/simulate_py_input.md
+++ b/documentation/simulate_py_input.md
@@ -1,0 +1,54 @@
+# simulate_py 入力JSON仕様
+
+`simulate_py` 関数に渡す文字列は `SimRequest` 構造体を JSON として表現したものです。
+以下に基本的なフォーマットと各フィールドの意味を示します。
+
+## ルート構造
+```json
+{
+  "ticks": 5,
+  "early_exit": true,
+  "world": {
+    "blocks": [
+      { "x": 0, "y": 0, "z": 0, "type": "lever", "on": true },
+      { "x": 1, "y": 0, "z": 0, "type": "dust",  "power": 0 },
+      { "x": 2, "y": 0, "z": 0, "type": "lamp",  "on": false }
+    ]
+  }
+}
+```
+
+- **ticks**: シミュレーションを最大で何 tick 実行するかを指定します。
+- **early_exit**: `true` の場合、状態変化が無くなり内部タイマーも停止した時点でシミュレーションを終了します。省略した場合は `true` になります。
+- **world.blocks**: ブロック一覧を配列で指定します。各要素はブロックの座標と種類を表します。
+
+## ブロック指定
+各ブロックは以下のように座標 (`x`, `y`, `z`) と `type` を持ち、種類に応じた追加フィールドを指定します。
+
+| type       | フィールド例                              | 説明                                     |
+|------------|------------------------------------------|------------------------------------------|
+| `lever`    | `{ "on": true }`                        | レバーの初期状態。                        |
+| `button`   | `{ "ticks_remaining": 0 }`              | ボタンが押されている残り tick 数。        |
+| `dust`     | `{ "power": 0 }`                        | レッドストーンダストの出力レベル (0–15)。 |
+| `lamp`     | `{ "on": false }`                       | ランプの点灯状態。                        |
+| `repeater` | `{ "delay": 1, "ticks_remaining": 0, "powered": false }` | リピータの遅延と現在状態。 |
+| `comparator` | `{ "output": 0 }`                    | 比較器の出力レベル (0–15)。               |
+| `torch`    | `{ "lit": true }`                       | レッドストーントーチが点灯しているか。    |
+| `piston`   | `{ "extended": false }`                 | ピストンが伸びているかどうか。            |
+| `hopper`   | `{ "enabled": true }`                   | ホッパーが動作しているかどうか。          |
+
+座標やフィールドの値は整数 (i32) または真偽値です。
+
+## 例
+上記の JSON を `simulate_py` に渡すと、レバーをオンにした状態から始まり、隣接するダストを介してランプが点灯するかを確認できます。
+
+```python
+import redstonesim
+
+request_json = """{...上記の JSON...}"""
+result = redstonesim.simulate_py(request_json)
+print(result)
+```
+
+`simulate_py` は結果も JSON 文字列として返します。`serde_json` などを用いて `SimResponse` として解釈できます。
+


### PR DESCRIPTION
## Summary
- document JSON format for the `simulate_py` API

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68780119720083209a276823e61128b2