### PR TITLE
Add Connectable trait and expose connection query

### DIFF
--- a/documentation/simulate_py_input.md
+++ b/documentation/simulate_py_input.md
@@ -53,3 +53,17 @@ print(result)
 
 `simulate_py` は結果も JSON 文字列として返します。`serde_json` などを用いて `SimResponse` として解釈できます。
 
+## ブロックの接続点を取得する
+`block_connections_py` 関数に `PlacedBlock` を表す JSON を渡すと、そのブロックが
+どの位置から入力を受け取り、どこへ出力するかを問い合わせられます。
+
+```python
+import redstonesim
+
+block_json = '{"x":0,"y":0,"z":0,"type":"dust","power":0}'
+info = redstonesim.block_connections_py(block_json)
+print(info)  # => {"inputs": [...], "outputs": [...]}
+```
+
+結果も JSON 文字列で、`inputs` と `outputs` の配列に各座標が含まれます。
+

--- a/src/py.rs
+++ b/src/py.rs
@@ -1,4 +1,4 @@
-use crate::{simulate, SimRequest};
+use crate::{simulate, Connectable, PlacedBlock, SimRequest};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
@@ -19,10 +19,25 @@ fn simulate_py(json_text: &str) -> PyResult<String> {
     simulate_impl(json_text)
 }
 
+fn connections_impl(json_text: &str) -> PyResult<String> {
+    let block: PlacedBlock =
+        serde_json::from_str(json_text).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let inputs = block.kind.input_positions(block.pos);
+    let outputs = block.kind.output_positions(block.pos);
+    let resp = serde_json::json!({ "inputs": inputs, "outputs": outputs });
+    serde_json::to_string(&resp).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+#[pyfunction]
+fn block_connections_py(json_text: &str) -> PyResult<String> {
+    connections_impl(json_text)
+}
+
 // ─── モジュール初期化関数 ────────────────────────────
 //            ↓↓↓ ここを &Bound<'_, PyModule> に変更
 #[pymodule]
 fn redstonesim(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(simulate_py, m)?);
+    m.add_function(wrap_pyfunction!(block_connections_py, m)?);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- introduce a `Connectable` trait for blocks
- implement the trait for all block kinds
- use the new trait in simulation instead of hard-coded direction loops
- expose `block_connections_py` to Python to query connection points
- document how to call the new Python API

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68787ff56370832091d36f2b9f256ebd