### PR TITLE
Add dirty block set for efficient updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 // =================================================
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // -------------------------------------------------
 // Position
@@ -282,158 +282,187 @@ pub fn simulate(request: SimRequest) -> SimResponse {
         }
     }
 
+    fn mark_outputs(block: &BlockKind, pos: Pos, set: &mut HashSet<Pos>) {
+        for n in block.output_positions(pos) {
+            set.insert(n);
+        }
+    }
+
+    let mut dirty: HashSet<Pos> = world.keys().cloned().collect();
+
     for tick in 1..=request.ticks {
         let mut changes: Vec<BlockChange> = Vec::new();
-
-        // take a snapshot of the world so we can query neighbor states
         let snapshot = world.clone();
+        let mut next_dirty: HashSet<Pos> = HashSet::new();
 
-        // update blocks based on neighbor power
-        for (pos, block) in world.iter_mut() {
-            match block {
-                BlockKind::Button { ticks_remaining } => {
-                    if *ticks_remaining > 0 {
-                        *ticks_remaining -= 1;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                    }
-                }
-                BlockKind::Repeater { delay, ticks_remaining, powered, facing } => {
-                    // input power from the back only
-                    let back = facing.opposite();
-                    let (dx, dy, dz) = back.offset();
-                    let n = Pos { x: pos.x + dx, y: pos.y + dy, z: pos.z + dz };
-                    let mut input = 0;
-                    if let Some(nb) = snapshot.get(&n) {
-                        input = output_towards(nb, *facing);
-                    }
-
-                    if input > 0 {
-                        if !*powered && *ticks_remaining == 0 {
-                            *ticks_remaining = *delay;
-                        }
-                    } else {
-                        *powered = false;
-                        *ticks_remaining = 0;
-                    }
-
-                    if *ticks_remaining > 0 {
-                        *ticks_remaining -= 1;
-                        if *ticks_remaining == 0 && input > 0 {
-                            *powered = true;
-                        }
-                    }
-
-                    changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                }
-                BlockKind::Comparator { output, .. } => {
-                    let mut new_out = 0;
-                    for n in block.input_positions(*pos) {
-                        if let Some(nb) = snapshot.get(&n) {
-                            let dir = dir_from_to(n, *pos);
-                            new_out = new_out.max(output_towards(nb, dir));
-                        }
-                    }
-                    if *output != new_out {
-                        *output = new_out;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                    }
-                }
-                BlockKind::Dust { power } => {
-                    let mut new_power = 0;
-                    for n in block.input_positions(*pos) {
-                        if let Some(nb) = snapshot.get(&n) {
-                            let dir = dir_from_to(n, *pos);
-                            let pw = output_towards(nb, dir);
-                            let candidate = match nb {
-                                BlockKind::Dust { power: p, .. } => p.saturating_sub(1),
-                                _ => pw,
-                            };
-                            new_power = new_power.max(candidate);
-                        }
-                    }
-                    if *power != new_power {
-                        *power = new_power;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                    }
-                }
-                BlockKind::Lamp { on } => {
-                    let mut powered = false;
-                    for n in block.input_positions(*pos) {
-                        if let Some(nb) = snapshot.get(&n) {
-                            let dir = dir_from_to(n, *pos);
-                            if output_towards(nb, dir) > 0 {
-                                powered = true;
-                                break;
+        for pos in dirty.iter() {
+            if let Some(block) = world.get_mut(pos) {
+                match block {
+                    BlockKind::Button { ticks_remaining } => {
+                        if *ticks_remaining > 0 {
+                            let prev_output = 15;
+                            *ticks_remaining -= 1;
+                            let new_output = if *ticks_remaining > 0 { 15 } else { 0 };
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                            if prev_output != new_output {
+                                mark_outputs(block, *pos, &mut next_dirty);
+                            }
+                            if *ticks_remaining > 0 {
+                                next_dirty.insert(*pos);
                             }
                         }
                     }
-                    if *on != powered {
-                        *on = powered;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                    }
-                }
-                BlockKind::Torch { lit, facing } => {
-                    let mut powered = false;
-                    let (dx, dy, dz) = facing.offset();
-                    let n = Pos { x: pos.x + dx, y: pos.y + dy, z: pos.z + dz };
-                    if let Some(nb) = snapshot.get(&n) {
-                        if output_towards(nb, facing.opposite()) > 0 {
-                            powered = true;
-                        }
-                    }
-                    let new_lit = !powered;
-                    if *lit != new_lit {
-                        *lit = new_lit;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                    }
-                }
-                BlockKind::Piston { extended, .. } => {
-                    let mut powered = false;
-                    for n in block.input_positions(*pos) {
+                    BlockKind::Repeater { delay, ticks_remaining, powered, facing } => {
+                        let back = facing.opposite();
+                        let (dx, dy, dz) = back.offset();
+                        let n = Pos { x: pos.x + dx, y: pos.y + dy, z: pos.z + dz };
+                        let mut input = 0;
                         if let Some(nb) = snapshot.get(&n) {
-                            let dir = dir_from_to(n, *pos);
-                            if output_towards(nb, dir) > 0 {
-                                powered = true;
-                                break;
+                            input = output_towards(nb, *facing);
+                        }
+
+                        let prev_output = if *powered { 15 } else { 0 };
+
+                        if input > 0 {
+                            if !*powered && *ticks_remaining == 0 {
+                                *ticks_remaining = *delay;
+                            }
+                        } else {
+                            *powered = false;
+                            *ticks_remaining = 0;
+                        }
+
+                        if *ticks_remaining > 0 {
+                            *ticks_remaining -= 1;
+                            if *ticks_remaining == 0 && input > 0 {
+                                *powered = true;
                             }
                         }
-                    }
-                    if *extended != powered {
-                        *extended = powered;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
-                    }
-                }
-                BlockKind::Hopper { enabled, .. } => {
-                    let mut powered = false;
-                    for n in block.input_positions(*pos) {
-                        if let Some(nb) = snapshot.get(&n) {
-                            let dir = dir_from_to(n, *pos);
-                            if output_towards(nb, dir) > 0 {
-                                powered = true;
-                                break;
-                            }
+
+                        let new_output = if *powered { 15 } else { 0 };
+
+                        if prev_output != new_output || *ticks_remaining != 0 {
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                        }
+
+                        if prev_output != new_output {
+                            mark_outputs(block, *pos, &mut next_dirty);
+                        }
+
+                        if *ticks_remaining > 0 {
+                            next_dirty.insert(*pos);
                         }
                     }
-                    let new_enabled = !powered;
-                    if *enabled != new_enabled {
-                        *enabled = new_enabled;
-                        changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                    BlockKind::Comparator { output, .. } => {
+                        let mut new_out = 0;
+                        for n in block.input_positions(*pos) {
+                            if let Some(nb) = snapshot.get(&n) {
+                                let dir = dir_from_to(n, *pos);
+                                new_out = new_out.max(output_towards(nb, dir));
+                            }
+                        }
+                        if *output != new_out {
+                            *output = new_out;
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                            mark_outputs(block, *pos, &mut next_dirty);
+                        }
                     }
+                    BlockKind::Dust { power } => {
+                        let mut new_power = 0;
+                        for n in block.input_positions(*pos) {
+                            if let Some(nb) = snapshot.get(&n) {
+                                let dir = dir_from_to(n, *pos);
+                                let pw = output_towards(nb, dir);
+                                let candidate = match nb {
+                                    BlockKind::Dust { power: p, .. } => p.saturating_sub(1),
+                                    _ => pw,
+                                };
+                                new_power = new_power.max(candidate);
+                            }
+                        }
+                        if *power != new_power {
+                            *power = new_power;
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                            mark_outputs(block, *pos, &mut next_dirty);
+                        }
+                    }
+                    BlockKind::Lamp { on } => {
+                        let mut powered = false;
+                        for n in block.input_positions(*pos) {
+                            if let Some(nb) = snapshot.get(&n) {
+                                let dir = dir_from_to(n, *pos);
+                                if output_towards(nb, dir) > 0 {
+                                    powered = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if *on != powered {
+                            *on = powered;
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                        }
+                    }
+                    BlockKind::Torch { lit, facing } => {
+                        let mut powered = false;
+                        let (dx, dy, dz) = facing.offset();
+                        let n = Pos { x: pos.x + dx, y: pos.y + dy, z: pos.z + dz };
+                        if let Some(nb) = snapshot.get(&n) {
+                            if output_towards(nb, facing.opposite()) > 0 {
+                                powered = true;
+                            }
+                        }
+                        let new_lit = !powered;
+                        if *lit != new_lit {
+                            *lit = new_lit;
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                            mark_outputs(block, *pos, &mut next_dirty);
+                        }
+                    }
+                    BlockKind::Piston { extended, .. } => {
+                        let mut powered = false;
+                        for n in block.input_positions(*pos) {
+                            if let Some(nb) = snapshot.get(&n) {
+                                let dir = dir_from_to(n, *pos);
+                                if output_towards(nb, dir) > 0 {
+                                    powered = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if *extended != powered {
+                            *extended = powered;
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                            mark_outputs(block, *pos, &mut next_dirty);
+                        }
+                    }
+                    BlockKind::Hopper { enabled, .. } => {
+                        let mut powered = false;
+                        for n in block.input_positions(*pos) {
+                            if let Some(nb) = snapshot.get(&n) {
+                                let dir = dir_from_to(n, *pos);
+                                if output_towards(nb, dir) > 0 {
+                                    powered = true;
+                                    break;
+                                }
+                            }
+                        }
+                        let new_enabled = !powered;
+                        if *enabled != new_enabled {
+                            *enabled = new_enabled;
+                            changes.push(BlockChange { pos: *pos, kind: block.clone() });
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
         }
 
-        // 4️⃣ diff collection & termination check
         if !changes.is_empty() {
             diffs.push(TickDiff { tick, changes });
         } else if request.early_exit {
-            // no visible changes —> check if any timer still running
             let timers_active = world.values().any(|b| match b {
                 BlockKind::Button { ticks_remaining } if *ticks_remaining > 0 => true,
-                BlockKind::Repeater {
-                    ticks_remaining, ..
-                } if *ticks_remaining > 0 => true,
+                BlockKind::Repeater { ticks_remaining, .. } if *ticks_remaining > 0 => true,
                 _ => false,
             });
             if !timers_active {
@@ -443,6 +472,8 @@ pub fn simulate(request: SimRequest) -> SimResponse {
                 };
             }
         }
+
+        dirty = next_dirty;
     }
 
     SimResponse {


### PR DESCRIPTION
## Summary
- track dirty blocks to only update changed areas
- propagate updates to neighbor blocks only when output changes

## Testing
- `cargo check` *(fails: failed to download crates, network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68788967f0bc8320997b62802da1732e